### PR TITLE
Command line argument: import_forwader.

### DIFF
--- a/protoc-gen-grpc-gateway/descriptor/registry.go
+++ b/protoc-gen-grpc-gateway/descriptor/registry.go
@@ -37,9 +37,9 @@ type Registry struct {
 	// allowDeleteBody permits http delete methods to have a body
 	allowDeleteBody bool
 
-	// ForwaderPkg is a package that contains implementations for
+	// forwardResponsePkg is a package that contains implementations for
 	// ForwardResponseMessage and ForwardResponseStream. May be nil
-	ForwaderPkg *GoPackage
+	forwardResponsePkg *GoPackage
 }
 
 // NewRegistry returns a new Registry.
@@ -226,10 +226,11 @@ func (r *Registry) SetImportPath(importPath string) {
 	r.importPath = importPath
 }
 
-// SetForwaderPkg sets a package that contains implementations for
+// SetForwardResponsePkg sets a package that contains implementations for
 // ForwardResponseMessage and ForwardResponseStream. It must be relative path.
-func (r *Registry) SetForwaderPkg(value string) error {
+func (r *Registry) SetForwardResponsePkg(value string) error {
 	glog.V(2).Infof("setting import_forwader: %s", value)
+
 	if value == "" {
 		return nil
 	}
@@ -254,11 +255,17 @@ func (r *Registry) SetForwaderPkg(value string) error {
 		}
 	}
 
-	r.ForwaderPkg = pkg
+	r.forwardResponsePkg = pkg
 
-	glog.V(2).Infof("import_forwader set to: %v", r.ForwaderPkg)
+	glog.V(2).Infof("import_forwader set to: %v", r.forwardResponsePkg)
 
 	return nil
+}
+
+// ForwardResponsePkg returns a package that contains implementations for
+// ForwardResponseMessage and ForwardResponseStream. May be nil
+func (r *Registry) ForwardResponsePkg() *GoPackage {
+	return r.forwardResponsePkg
 }
 
 // ReserveGoPackageAlias reserves the unique alias of go package.

--- a/protoc-gen-grpc-gateway/descriptor/registry.go
+++ b/protoc-gen-grpc-gateway/descriptor/registry.go
@@ -229,7 +229,7 @@ func (r *Registry) SetImportPath(importPath string) {
 // SetForwardResponsePkg sets a package that contains implementations for
 // ForwardResponseMessage and ForwardResponseStream. It must be relative path.
 func (r *Registry) SetForwardResponsePkg(value string) error {
-	glog.V(2).Infof("setting import_forwader: %s", value)
+	glog.V(2).Infof("setting import_forwarder: %s", value)
 
 	if value == "" {
 		return nil
@@ -257,7 +257,7 @@ func (r *Registry) SetForwardResponsePkg(value string) error {
 
 	r.forwardResponsePkg = pkg
 
-	glog.V(2).Infof("import_forwader set to: %v", r.forwardResponsePkg)
+	glog.V(2).Infof("import_forwarder set to: %v", r.forwardResponsePkg)
 
 	return nil
 }

--- a/protoc-gen-grpc-gateway/descriptor/registry_test.go
+++ b/protoc-gen-grpc-gateway/descriptor/registry_test.go
@@ -549,3 +549,31 @@ func TestLoadOverridedPackageName(t *testing.T) {
 		t.Errorf("file.GoPkg = %#v; want %#v", got, want)
 	}
 }
+
+func TestSetForwaderPkg(t *testing.T) {
+	reg := NewRegistry()
+
+	// set absolute path
+	if err := reg.SetForwaderPkg("/root"); err == nil {
+		t.Error("reg.SetForwaderPkg(/absolute/path) - ok; absolute path cannot be used as a forwader package")
+	}
+
+	var value = "github.com/grpc-ecosystem/grpc-gateway/runtime"
+	// set valid package name
+	if err := reg.SetForwaderPkg(value); err != nil {
+		t.Error("reg.SetForwaderPkg - failed to set forwader package")
+	}
+	if reg.ForwaderPkg.Name != "runtime" {
+		t.Errorf("invalid  value reg.ForwaderPkg.Name = %q, expected %q", reg.ForwaderPkg.Name, "runtime")
+	}
+	if reg.ForwaderPkg.Path != value {
+		t.Errorf("invalid  value reg.ForwaderPkg.Path = %q, expected %q", reg.ForwaderPkg.Path, value)
+	}
+	if reg.ForwaderPkg.Alias != "" {
+		t.Errorf("invalid  value reg.ForwaderPkg.Alias = %q, expected %q", reg.ForwaderPkg.Alias, "runtime_1")
+	}
+
+	if err := reg.SetForwaderPkg(""); err != nil {
+		t.Error("reg.SetForwaderPkg- failed to set empty forwader package")
+	}
+}

--- a/protoc-gen-grpc-gateway/descriptor/registry_test.go
+++ b/protoc-gen-grpc-gateway/descriptor/registry_test.go
@@ -550,30 +550,46 @@ func TestLoadOverridedPackageName(t *testing.T) {
 	}
 }
 
-func TestSetForwaderPkg(t *testing.T) {
+func TestSetForwardResponsePkg(t *testing.T) {
 	reg := NewRegistry()
 
 	// set absolute path
-	if err := reg.SetForwaderPkg("/root"); err == nil {
-		t.Error("reg.SetForwaderPkg(/absolute/path) - ok; absolute path cannot be used as a forwader package")
+	if err := reg.SetForwardResponsePkg("/root"); err == nil {
+		t.Error("reg.SetForwardResponsePkg(/absolute/path) - ok; absolute path cannot be used as a forward response package")
 	}
 
 	var value = "github.com/grpc-ecosystem/grpc-gateway/runtime"
-	// set valid package name
-	if err := reg.SetForwaderPkg(value); err != nil {
-		t.Error("reg.SetForwaderPkg - failed to set forwader package")
+	// set standard package name
+	if err := reg.SetForwardResponsePkg(value); err != nil {
+		t.Error("reg.SetForwardResponsePkg - failed to set standard forward response package")
 	}
-	if reg.ForwaderPkg.Name != "runtime" {
-		t.Errorf("invalid  value reg.ForwaderPkg.Name = %q, expected %q", reg.ForwaderPkg.Name, "runtime")
+	if reg.ForwardResponsePkg().Name != "runtime" {
+		t.Errorf("invalid  value reg.ForwardResponsePkg().Name = %q, expected %q", reg.ForwardResponsePkg().Name, "runtime")
 	}
-	if reg.ForwaderPkg.Path != value {
-		t.Errorf("invalid  value reg.ForwaderPkg.Path = %q, expected %q", reg.ForwaderPkg.Path, value)
+	if reg.ForwardResponsePkg().Path != value {
+		t.Errorf("invalid  value reg.ForwardResponsePkg().Path = %q, expected %q", reg.ForwardResponsePkg().Path, value)
 	}
-	if reg.ForwaderPkg.Alias != "" {
-		t.Errorf("invalid  value reg.ForwaderPkg.Alias = %q, expected %q", reg.ForwaderPkg.Alias, "runtime_1")
+	if reg.ForwardResponsePkg().Alias != "" {
+		t.Errorf("invalid  value reg.ForwardResponsePkg().Alias = %q, expected %q", reg.ForwardResponsePkg().Alias, "")
 	}
 
-	if err := reg.SetForwaderPkg(""); err != nil {
-		t.Error("reg.SetForwaderPkg- failed to set empty forwader package")
+	// set external package name
+	value = "github.com/third-party-lib/runtime"
+	if err := reg.SetForwardResponsePkg(value); err != nil {
+		t.Error("reg.SetForwardResponsePkg - failed to set external forward response package")
+	}
+	if reg.ForwardResponsePkg().Name != "runtime" {
+		t.Errorf("invalid  value reg.ForwardResponsePkg().Name = %q, expected %q", reg.ForwardResponsePkg().Name, "runtime")
+	}
+	if reg.ForwardResponsePkg().Path != value {
+		t.Errorf("invalid  value reg.ForwardResponsePkg().Path = %q, expected %q", reg.ForwardResponsePkg().Path, value)
+	}
+	if reg.ForwardResponsePkg().Alias != "runtime_0" {
+		t.Errorf("invalid  value reg.ForwardResponsePkg().Alias = %q, expected %q", reg.ForwardResponsePkg().Alias, "runtime_0")
+	}
+
+	// set empty package
+	if err := reg.SetForwardResponsePkg(""); err != nil {
+		t.Error("reg.SetForwardResponsePkg- failed to set empty forward response package")
 	}
 }

--- a/protoc-gen-grpc-gateway/gengateway/generator_test.go
+++ b/protoc-gen-grpc-gateway/gengateway/generator_test.go
@@ -123,7 +123,7 @@ func TestGenerateOutputPath(t *testing.T) {
 		},
 	}
 
-	g := &generator{}
+	g := &generator{forwaderPkg: "runtime"}
 	for _, c := range cases {
 		file := c.file
 		gots, err := g.Generate([]*descriptor.File{crossLinkFixture(file)})
@@ -149,5 +149,30 @@ func TestGenerateOutputPath(t *testing.T) {
 			t.Errorf("Generate(%#v) failed; got path: %s expected path: %s", file, gotPath, expectedPath)
 			return
 		}
+	}
+}
+
+func TestForwaderPkg(t *testing.T) {
+	reg := descriptor.NewRegistry()
+
+	if err := reg.SetForwaderPkg("github.com/grpc-ecosystem/grpc-gateway/fw"); err != nil {
+		t.Errorf("failed to set ForwaderPkg: %s", err)
+	}
+
+	gen := New(reg, true)
+	g := gen.(*generator)
+	if g.forwaderPkg != "fw" {
+		t.Errorf("invalid forwaderPkg = %q, expected = %q", g.forwaderPkg, "fw")
+	}
+
+	reg = descriptor.NewRegistry()
+	if err := reg.SetForwaderPkg(""); err != nil {
+		t.Errorf("failed to set forwaderPkg: %s", err)
+	}
+
+	gen = New(reg, true)
+	g = gen.(*generator)
+	if g.forwaderPkg != "runtime" {
+		t.Errorf("invalid forwaderPkg = %q, expected = %q", g.forwaderPkg, "runtime")
 	}
 }

--- a/protoc-gen-grpc-gateway/gengateway/generator_test.go
+++ b/protoc-gen-grpc-gateway/gengateway/generator_test.go
@@ -123,7 +123,7 @@ func TestGenerateOutputPath(t *testing.T) {
 		},
 	}
 
-	g := &generator{forwaderPkg: "runtime"}
+	g := &generator{forwardResponsePkg: "runtime"}
 	for _, c := range cases {
 		file := c.file
 		gots, err := g.Generate([]*descriptor.File{crossLinkFixture(file)})
@@ -152,27 +152,29 @@ func TestGenerateOutputPath(t *testing.T) {
 	}
 }
 
-func TestForwaderPkg(t *testing.T) {
+func TestForwadResponsePgk(t *testing.T) {
 	reg := descriptor.NewRegistry()
 
-	if err := reg.SetForwaderPkg("github.com/grpc-ecosystem/grpc-gateway/fw"); err != nil {
-		t.Errorf("failed to set ForwaderPkg: %s", err)
+	// custom name - forward response package is set
+	if err := reg.SetForwardResponsePkg("github.com/grpc-ecosystem/grpc-gateway/fw"); err != nil {
+		t.Errorf("failed to set ForwardResponsePkg: %s", err)
 	}
 
 	gen := New(reg, true)
 	g := gen.(*generator)
-	if g.forwaderPkg != "fw" {
-		t.Errorf("invalid forwaderPkg = %q, expected = %q", g.forwaderPkg, "fw")
+	if g.forwardResponsePkg != "fw" {
+		t.Errorf("invalid forwardResponsePkg = %q, expected = %q", g.forwardResponsePkg, "fw")
 	}
 
 	reg = descriptor.NewRegistry()
-	if err := reg.SetForwaderPkg(""); err != nil {
-		t.Errorf("failed to set forwaderPkg: %s", err)
+	if err := reg.SetForwardResponsePkg(""); err != nil {
+		t.Errorf("failed to set empty forwardResponsePkg: %s", err)
 	}
 
+	// default name - forward response package is not set
 	gen = New(reg, true)
 	g = gen.(*generator)
-	if g.forwaderPkg != "runtime" {
-		t.Errorf("invalid forwaderPkg = %q, expected = %q", g.forwaderPkg, "runtime")
+	if g.forwardResponsePkg != "runtime" {
+		t.Errorf("invalid forwardResponsePkg = %q, expected = %q", g.forwardResponsePkg, "runtime")
 	}
 }

--- a/protoc-gen-grpc-gateway/gengateway/template.go
+++ b/protoc-gen-grpc-gateway/gengateway/template.go
@@ -13,9 +13,9 @@ import (
 
 type param struct {
 	*descriptor.File
-	Imports           []descriptor.GoPackage
-	UseRequestContext bool
-	ForwaderPkg       string
+	Imports            []descriptor.GoPackage
+	UseRequestContext  bool
+	ForwardResponsePkg string
 }
 
 type binding struct {
@@ -69,9 +69,9 @@ func (f queryParamFilter) String() string {
 }
 
 type trailerParams struct {
-	Services          []*descriptor.Service
-	UseRequestContext bool
-	ForwaderPkg       string
+	Services           []*descriptor.Service
+	UseRequestContext  bool
+	ForwardResponsePkg string
 }
 
 func applyTemplate(p param) (string, error) {
@@ -102,9 +102,9 @@ func applyTemplate(p param) (string, error) {
 	}
 
 	tp := trailerParams{
-		Services:          targetServices,
-		UseRequestContext: p.UseRequestContext,
-		ForwaderPkg:       p.ForwaderPkg,
+		Services:           targetServices,
+		UseRequestContext:  p.UseRequestContext,
+		ForwardResponsePkg: p.ForwardResponsePkg,
 	}
 	if err := trailerTemplate.Execute(w, tp); err != nil {
 		return "", err
@@ -312,7 +312,7 @@ var (
 
 	trailerTemplate = template.Must(template.New("trailer").Parse(`
 {{$UseRequestContext := .UseRequestContext}}
-{{$ForwaderPkg := .ForwaderPkg}}
+{{$ForwardResponsePkg := .ForwardResponsePkg}}
 {{range $svc := .Services}}
 // Register{{$svc.GetName}}HandlerFromEndpoint is same as Register{{$svc.GetName}}Handler but
 // automatically dials to "endpoint" and closes the connection when "ctx" gets done.
@@ -403,7 +403,7 @@ var (
 var (
 	{{range $m := $svc.Methods}}
 	{{range $b := $m.Bindings}}
-	forward_{{$svc.GetName}}_{{$m.GetName}}_{{$b.Index}} = {{$ForwaderPkg}}.{{if $m.GetServerStreaming}}ForwardResponseStream{{else}}ForwardResponseMessage{{end}}
+	forward_{{$svc.GetName}}_{{$m.GetName}}_{{$b.Index}} = {{$ForwardResponsePkg}}.{{if $m.GetServerStreaming}}ForwardResponseStream{{else}}ForwardResponseMessage{{end}}
 	{{end}}
 	{{end}}
 )

--- a/protoc-gen-grpc-gateway/gengateway/template_test.go
+++ b/protoc-gen-grpc-gateway/gengateway/template_test.go
@@ -222,7 +222,7 @@ func TestApplyTemplateRequestWithoutClientStreaming(t *testing.T) {
 				},
 			},
 		}
-		got, err := applyTemplate(param{File: crossLinkFixture(&file)})
+		got, err := applyTemplate(param{File: crossLinkFixture(&file), ForwaderPkg: "runtime"})
 		if err != nil {
 			t.Errorf("applyTemplate(%#v) failed with %v; want success", file, err)
 			return
@@ -244,6 +244,9 @@ func TestApplyTemplateRequestWithoutClientStreaming(t *testing.T) {
 		}
 		if want := `pattern_ExampleService_Echo_0 = runtime.MustPattern(runtime.NewPattern(1, []int{0, 0}, []string(nil), ""))`; !strings.Contains(got, want) {
 			t.Errorf("applyTemplate(%#v) = %s; want to contain %s", file, got, want)
+		}
+		if want := `forward_ExampleService_Echo_0 = runtime.ForwardResponse`; !strings.Contains(got, want) {
+			t.Errorf("applytTemplate(%#v) = %s; want to contain %s", file, got, want)
 		}
 	}
 }
@@ -383,7 +386,7 @@ func TestApplyTemplateRequestWithClientStreaming(t *testing.T) {
 				},
 			},
 		}
-		got, err := applyTemplate(param{File: crossLinkFixture(&file)})
+		got, err := applyTemplate(param{File: crossLinkFixture(&file), ForwaderPkg: "nonstandard"})
 		if err != nil {
 			t.Errorf("applyTemplate(%#v) failed with %v; want success", file, err)
 			return
@@ -399,6 +402,9 @@ func TestApplyTemplateRequestWithClientStreaming(t *testing.T) {
 		}
 		if want := `pattern_ExampleService_Echo_0 = runtime.MustPattern(runtime.NewPattern(1, []int{0, 0}, []string(nil), ""))`; !strings.Contains(got, want) {
 			t.Errorf("applyTemplate(%#v) = %s; want to contain %s", file, got, want)
+		}
+		if want := `forward_ExampleService_Echo_0 = nonstandard.ForwardResponse`; !strings.Contains(got, want) {
+			t.Errorf("applytTemplate(%#v) = %s; want to contain %s", file, got, want)
 		}
 	}
 }

--- a/protoc-gen-grpc-gateway/gengateway/template_test.go
+++ b/protoc-gen-grpc-gateway/gengateway/template_test.go
@@ -222,7 +222,7 @@ func TestApplyTemplateRequestWithoutClientStreaming(t *testing.T) {
 				},
 			},
 		}
-		got, err := applyTemplate(param{File: crossLinkFixture(&file), ForwaderPkg: "runtime"})
+		got, err := applyTemplate(param{File: crossLinkFixture(&file), ForwardResponsePkg: "runtime"})
 		if err != nil {
 			t.Errorf("applyTemplate(%#v) failed with %v; want success", file, err)
 			return
@@ -386,7 +386,7 @@ func TestApplyTemplateRequestWithClientStreaming(t *testing.T) {
 				},
 			},
 		}
-		got, err := applyTemplate(param{File: crossLinkFixture(&file), ForwaderPkg: "nonstandard"})
+		got, err := applyTemplate(param{File: crossLinkFixture(&file), ForwardResponsePkg: "nonstandard"})
 		if err != nil {
 			t.Errorf("applyTemplate(%#v) failed with %v; want success", file, err)
 			return

--- a/protoc-gen-grpc-gateway/main.go
+++ b/protoc-gen-grpc-gateway/main.go
@@ -27,7 +27,7 @@ var (
 	importPath         = flag.String("import_path", "", "used as the package if no input files declare go_package. If it contains slashes, everything up to the rightmost slash is ignored.")
 	useRequestContext  = flag.Bool("request_context", true, "determine whether to use http.Request's context or not")
 	allowDeleteBody    = flag.Bool("allow_delete_body", false, "unless set, HTTP DELETE methods may not have a body")
-	forwardResponsePkg = flag.String("import_forwader", "", "a package that contains implementations for ForwardResponseMessage and ForwardResponseStream")
+	forwardResponsePkg = flag.String("import_forwarder", "", "a package that contains implementations for ForwardResponseMessage and ForwardResponseStream")
 )
 
 func parseReq(r io.Reader) (*plugin.CodeGeneratorRequest, error) {
@@ -79,7 +79,7 @@ func main() {
 
 	// gengateway.New depends on registry.ForwardResponsePkg so set it first.
 	if err := reg.SetForwardResponsePkg(*forwardResponsePkg); err != nil {
-		glog.Errorf("invalid import_forwader parameter: %s", err)
+		glog.Errorf("invalid import_forwarder parameter: %s", err)
 	}
 
 	g := gengateway.New(reg, *useRequestContext)

--- a/protoc-gen-grpc-gateway/main.go
+++ b/protoc-gen-grpc-gateway/main.go
@@ -27,6 +27,7 @@ var (
 	importPath        = flag.String("import_path", "", "used as the package if no input files declare go_package. If it contains slashes, everything up to the rightmost slash is ignored.")
 	useRequestContext = flag.Bool("request_context", true, "determine whether to use http.Request's context or not")
 	allowDeleteBody   = flag.Bool("allow_delete_body", false, "unless set, HTTP DELETE methods may not have a body")
+	forwaderPkg       = flag.String("import_forwader", "", "a package that contains implementations for ForwardResponseMessage and ForwardResponseStream")
 )
 
 func parseReq(r io.Reader) (*plugin.CodeGeneratorRequest, error) {
@@ -76,11 +77,16 @@ func main() {
 		}
 	}
 
+	if err := reg.SetForwaderPkg(*forwaderPkg); err != nil {
+		glog.Errorf("invalid import_forwader parameter: %s", err)
+	}
+
 	g := gengateway.New(reg, *useRequestContext)
 
 	reg.SetPrefix(*importPrefix)
 	reg.SetImportPath(*importPath)
 	reg.SetAllowDeleteBody(*allowDeleteBody)
+
 	if err := reg.Load(req); err != nil {
 		emitError(err)
 		return

--- a/protoc-gen-grpc-gateway/main.go
+++ b/protoc-gen-grpc-gateway/main.go
@@ -23,11 +23,11 @@ import (
 )
 
 var (
-	importPrefix      = flag.String("import_prefix", "", "prefix to be added to go package paths for imported proto files")
-	importPath        = flag.String("import_path", "", "used as the package if no input files declare go_package. If it contains slashes, everything up to the rightmost slash is ignored.")
-	useRequestContext = flag.Bool("request_context", true, "determine whether to use http.Request's context or not")
-	allowDeleteBody   = flag.Bool("allow_delete_body", false, "unless set, HTTP DELETE methods may not have a body")
-	forwaderPkg       = flag.String("import_forwader", "", "a package that contains implementations for ForwardResponseMessage and ForwardResponseStream")
+	importPrefix       = flag.String("import_prefix", "", "prefix to be added to go package paths for imported proto files")
+	importPath         = flag.String("import_path", "", "used as the package if no input files declare go_package. If it contains slashes, everything up to the rightmost slash is ignored.")
+	useRequestContext  = flag.Bool("request_context", true, "determine whether to use http.Request's context or not")
+	allowDeleteBody    = flag.Bool("allow_delete_body", false, "unless set, HTTP DELETE methods may not have a body")
+	forwardResponsePkg = flag.String("import_forwader", "", "a package that contains implementations for ForwardResponseMessage and ForwardResponseStream")
 )
 
 func parseReq(r io.Reader) (*plugin.CodeGeneratorRequest, error) {
@@ -77,7 +77,8 @@ func main() {
 		}
 	}
 
-	if err := reg.SetForwaderPkg(*forwaderPkg); err != nil {
+	// gengateway.New depends on registry.ForwardResponsePkg so set it first.
+	if err := reg.SetForwardResponsePkg(*forwardResponsePkg); err != nil {
 		glog.Errorf("invalid import_forwader parameter: %s", err)
 	}
 


### PR DESCRIPTION
When you want to provide consistency for all your applications that expose public REST API endpoints you need to put common `ForwardResponseMessage` and `ForwardResponseStream` in some place so that all your applications can import them and use as forwarders.

That is too boring and sometimes error-prone to overwrite default forwarders as described [here](https://github.com/grpc-ecosystem/grpc-gateway/wiki/How-to-customize-your-gateway#replace-a-response-forwarder-per-method).

This PR:
   - introduces new command line argument `import_forwarder` for `protoc-gen-grpc-gateway`
- `import_forwarder` indicates a package that contains implementations for ForwardResponseMessage and ForwardResponseStream
- during generation a package path provided by `import_forwarder` is used as an replacement of default `github.com/grpc-ecosystem/grpc-gateway/runtime` only for ForwardResponseMessage and ForwardResponseStream functions.
- if `import_forwarder` is not set `github.com/grpc-ecosystem/grpc-gateway/runtime` is used as usual.
